### PR TITLE
Add publisher fields to feed

### DIFF
--- a/lib/magpie-gem/feed.rb
+++ b/lib/magpie-gem/feed.rb
@@ -43,11 +43,11 @@ module Magpie
         @data[entity_name_plural] << item
         @data["#{entity_name_plural}_by_id"][item.id] = item
         item
-      end      
+      end
     }
 
-    attr_accessor :feed_provider
-    
+    attr_accessor :feed_provider, :publisher_email, :publisher_application, :publisher_application_version
+
     def initialize(attributes={})
       super
       @data = {}
@@ -83,6 +83,9 @@ module Magpie
     def as_json(options={})
       {
         feed_provider: feed_provider,
+        publisher_email: publisher_email,
+        publisher_application: publisher_application,
+        publisher_application_version: publisher_application_version,
         companies: companies,
         people: people,
         properties: properties,


### PR DESCRIPTION
application and application version may be used to decide what fields this feed is publishing. e.g. when application is 'simple_csv_importer' and version is '1.0.0', the importer on osnext will know which fields were entered by the user.